### PR TITLE
Correction for rosdep to work

### DIFF
--- a/src/arm_control/package.xml
+++ b/src/arm_control/package.xml
@@ -47,7 +47,7 @@
   <depend>kdl_parser</depend>
   <depend>orocos_kdl</depend>
   <depend>realtime_tools</depend>
-  <depend>gazebo-ros-control</depend>
+  <depend>gazebo_ros_control</depend>
   <depend>controller_interface</depend>
   <depend>joint_trajectory_controller</depend>
 


### PR DESCRIPTION
Name of gazebo-ros-control was incorrect (package found if using underscore instead of dash), which made `rosdep install` fail.